### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -10,6 +10,6 @@
     "repo": "googleapis/python-iam",
     "distribution_name": "google-cloud-iam",
     "api_id": "iam.googleapis.com",
-    "default_version": "",
+    "default_version": "v1",
     "codeowner_team": ""
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,13 +1,15 @@
 {
-  "name": "iam",
-  "name_pretty": "Cloud Identity and Access Management",
-  "product_documentation": "https://cloud.google.com/iam/docs/",
-  "client_documentation": "https://googleapis.dev/python/iam/latest",
-  "issue_tracker": "https://issuetracker.google.com/savedsearches/559761",
-  "release_level": "ga",
-  "language": "python",
-  "library_type": "GAPIC_AUTO",
-  "repo": "googleapis/python-iam",
-  "distribution_name": "google-cloud-iam",
-  "api_id": "iam.googleapis.com"
+    "name": "iam",
+    "name_pretty": "Cloud Identity and Access Management",
+    "product_documentation": "https://cloud.google.com/iam/docs/",
+    "client_documentation": "https://googleapis.dev/python/iam/latest",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559761",
+    "release_level": "ga",
+    "language": "python",
+    "library_type": "GAPIC_AUTO",
+    "repo": "googleapis/python-iam",
+    "distribution_name": "google-cloud-iam",
+    "api_id": "iam.googleapis.com",
+    "default_version": "",
+    "codeowner_team": ""
 }


### PR DESCRIPTION
By default the code owner will be googleapis/yoshi-python. This change is needed for the following synthtool PRs.

googleapis/synthtool#1201
googleapis/synthtool#1114
