### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "iam",
     "name_pretty": "Cloud Identity and Access Management",
     "product_documentation": "https://cloud.google.com/iam/docs/",
-    "client_documentation": "https://googleapis.dev/python/iam/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/iam/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559761",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ creation of service accounts, which you can use to authenticate to Google and ma
 
 .. _IAM API: https://cloud.google.com/iam
 
-.. _Client Library Documentation: https://googleapis.dev/python/iam/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/iam/latest
 .. _Product Documentation:  https://cloud.google.com/iam
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.