### PR TITLE
chore: update client documentation url to be consistent

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -3,7 +3,7 @@
     "name_pretty": "Cloud Identity and Access Management",
     "api_description": "Manages identity and access control for Google Cloud Platform resources, including the creation of service accounts, which you can use to authenticate to Google and make API calls.",
     "product_documentation": "https://cloud.google.com/iam/docs/",
-    "client_documentation": "https://cloud.google.com/python/docs/reference/iam/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/iamcredentials/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559761",
     "release_level": "stable",
     "language": "python",


### PR DESCRIPTION
`iam` has been renamed to `iamcredentials` for documentation usage, we should update it on repo metadata so it's properly picked up on other places as well, such as the README. 