### PR TITLE
chore: prepare for monorepo migration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,8 +4,8 @@ branch = True
 [report]
 show_missing = True
 omit =
-    google/cloud/iam_credentials/__init__.py
-    google/cloud/iam_credentials/gapic_version.py
+    google/cloud/iam/__init__.py
+    google/cloud/iam/gapic_version.py
 exclude_lines =
     # Re-enable the standard pragma
     pragma: NO COVER

--- a/.github/.OwlBot.yaml
+++ b/.github/.OwlBot.yaml
@@ -24,9 +24,9 @@ deep-preserve-regex:
 
 deep-copy-regex:
   - source: /google/iam/credentials/(v.*)/.*-py/(.*)
-    dest: /owl-bot-staging/iamcredentials/$1/$2
+    dest: /owl-bot-staging/$1/$2
   - source: /google/iam/(v.*)/.*-py/(.*)
-    dest: /owl-bot-staging/iam/$1/$2
+    dest: /owl-bot-staging/$1/$2
 
 begin-after-commit-hash: 130ce904e5d546c312943d10f48799590f9c0f66
 

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -11,7 +11,7 @@
     "repo": "googleapis/python-iam",
     "distribution_name": "google-cloud-iam",
     "api_id": "iam.googleapis.com",
-    "default_version": "v1",
+    "default_version": "v2",
     "codeowner_team": "",
     "api_shortname": "iamcredentials"
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,6 +2,9 @@
 
 .. include:: multiprocessing.rst
 
+This package includes clients for multiple versions of Cloud Identity and Access Management.
+By default, you will get version ``iam_v2``.
+
 
 API Reference
 -------------
@@ -26,6 +29,7 @@ API Reference
 
     iam_v2beta/services
     iam_v2beta/types
+
 
 Migration Guide
 ---------------


### PR DESCRIPTION
This PR migrates to a standard `owlbot.py file`, instead of a customized one. 

Here are the commands that I used to validate the change
- In a clone of googleapis/googleapis, run
`bazel build //google/iam/credentials/v1:iam-credentials-v1-py`
`bazel build //google/iam/v2:iam-v2-py`
`bazel build //google/iam/v2beta:iam-v2beta-py`

- In this branch, run owlbot copy code and the owlbot post processor

```
docker run --rm --user $(id -u):$(id -g)   -v $(pwd):/repo   -v $HOME/git/googleapis/bazel-bin:/bazel-bin   gcr.io/cloud-devrel-public-resources/owlbot-cli:latest copy-bazel-bin   --source-dir /bazel-bin --dest /repo
```

```
docker run --user $(id -u):$(id -g) --rm -v $(pwd):/repo -w /repo gcr.io/cloud-devrel-public-resources/owlbot-python:latest
```


Background
-----
The repository googleapis/python-iam contains code for 2 APIs [google/iam/credentials](https://github.com/googleapis/googleapis/tree/master/google/iam/credentials) and [google/iam](https://github.com/googleapis/googleapis/tree/master/google/iam)

The PR is removing custom logic in owlbot.py, and making the necessary changes in .Owlbot.yaml instead.